### PR TITLE
Issue 305 홈화면 헤더 알림아이콘 개선

### DIFF
--- a/src/apis/notification/index.js
+++ b/src/apis/notification/index.js
@@ -42,11 +42,24 @@ export const patchNotification = async (notification_id, read) => {
       read,
     });
 
-    console.log('patch response: ', response);
     if (response.status === 200) {
       console.log('Notification updated successfully');
     } else {
       console.error('Failed to update notification');
+    }
+  } catch (error) {
+    console.error('Error:', error);
+  }
+};
+
+export const deleteNotification = async (notification_id) => {
+  try {
+    const response = await API.delete(`/notification?notificationId=${notification_id}`);
+
+    if (response.status === 200) {
+      console.log('Notification deleted successfully');
+    } else {
+      console.error('Failed to delete notification');
     }
   } catch (error) {
     console.error('Error:', error);

--- a/src/components/HeaderComponents.jsx
+++ b/src/components/HeaderComponents.jsx
@@ -19,10 +19,17 @@ const appLogoImage = require('../assets/images/app-logo.png');
  * title: string
  * onRightBtnPress: () => void;
  * onDatePress: () => void;
+ * hasUnreadNotification: boolean
  * }} param0
  */
 
-const HeaderComponents = ({ icon = 'none', title = '', onRightBtnPress = () => {}, onDatePress = () => {} }) => {
+const HeaderComponents = ({
+  icon = 'none',
+  title = '',
+  onRightBtnPress = () => {},
+  onDatePress = () => {},
+  hasUnreadNotification,
+}) => {
   const navigation = useNavigation();
 
   const getRightBtn = () => {
@@ -30,7 +37,11 @@ const HeaderComponents = ({ icon = 'none', title = '', onRightBtnPress = () => {
       case 'home':
         return (
           <TouchableOpacity style={styles.btnWrapper} onPress={onRightBtnPress} activeOpacity={0.6}>
-            <MaterialCommunityIcons name="bell" size={24} color={COLORS.white} />
+            <MaterialCommunityIcons
+              name={hasUnreadNotification ? 'bell-badge' : 'bell'}
+              size={24}
+              color={COLORS.white}
+            />
           </TouchableOpacity>
         );
       case 'btn':

--- a/src/hooks/useNotificationUpdates.js
+++ b/src/hooks/useNotificationUpdates.js
@@ -3,20 +3,25 @@ import { useEffect } from 'react';
 
 import { sendNotification } from '../apis/notification';
 import { supabase } from '../lib/supabaseClient';
+import { useNotificationStore } from '../store/notification';
 import useUserStore from '../store/sign/login';
 
 /* eslint-disable */
 
 const useNotificationUpdates = () => {
   const { userId } = useUserStore();
+  const { notificationList, setNotificationList } = useNotificationStore();
+
   useEffect(() => {
     const channel = supabase
       .channel('notification')
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'notification' }, async (payload) => {
         const notification = payload.new;
+        console.log('notification update: ', payload.new);
         if (notification.member_id === userId) {
           const token = await messaging().getToken();
           await sendNotification(token, notification);
+          setNotificationList([notification, ...notificationList]);
         }
       })
       .subscribe();

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Image, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { getMyCompetition } from '../../apis/competition/index';
+import { getNotification } from '../../apis/notification';
 import HeaderComponents from '../../components/HeaderComponents';
 import HeatmapCalendar from '../../components/HeatMapCalendar';
 import MyCompetitionItem from '../../components/MyCompetitionItem';
@@ -13,6 +14,7 @@ import { FONT_SIZES, FONTS, HEADER_FONT_SIZES } from '../../constants/font';
 import { RADIUS } from '../../constants/radius';
 import { ELEMENT_VERTICAL_MARGIN, LAYOUT_PADDING, SPACING } from '../../constants/space';
 import { useCompetitionStore } from '../../store/competition';
+import { useNotificationStore } from '../../store/notification';
 import useUserStore from '../../store/sign/login';
 import { useToastMessageStore } from '../../store/toastMessage/toastMessage';
 
@@ -29,6 +31,7 @@ const Home = ({ navigation }) => {
   const [competition, setCompetition] = useState();
   const isFocused = useIsFocused(); // 현재 화면이 포커스 상태인지 확인
   const { nickname, profileImageUrl, introduce } = useUserStore();
+  const { notificationList, setNotificationList } = useNotificationStore();
   const { setCompetitionList } = useCompetitionStore();
   const { showToast } = useToastMessageStore();
 
@@ -60,10 +63,21 @@ const Home = ({ navigation }) => {
       showToast(`Error fetching competitions: ${error.message}`, 'error', 2000, 'top');
     }
   };
+
+  const fetchNotification = async () => {
+    try {
+      const result = await getNotification();
+      setNotificationList(result.data);
+    } catch (error) {
+      showToast(`알림 정보 조회 실패: ${error.message}`, 'error');
+    }
+  };
+
   /* eslint-disable */
   useEffect(() => {
     if (isFocused) {
       fetchMyCompetitions();
+      fetchNotification();
     }
   }, [isFocused]);
   /* eslint-enable */
@@ -78,7 +92,11 @@ const Home = ({ navigation }) => {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <HeaderComponents icon="home" onRightBtnPress={() => navigation.navigate('Notification')} />
+      <HeaderComponents
+        icon="home"
+        onRightBtnPress={() => navigation.navigate('Notification')}
+        hasUnreadNotification={notificationList.filter((notification) => notification.read === false).length > 0}
+      />
       <ScrollView contentContainerStyle={styles.scrollViewContent}>
         <ProfileSection data={{ nickname, profileImageUrl, introduce }} />
         <SectionTitle title="진행중인 경쟁" showMore={true} navigation={navigation} navigateTo="Competition" />

--- a/src/pages/notification/Notification.jsx
+++ b/src/pages/notification/Notification.jsx
@@ -1,11 +1,10 @@
-import { useIsFocused } from '@react-navigation/native';
 import dayjs from 'dayjs';
 import React from 'react';
 import { Dimensions, FlatList, SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { getCompetitionDetail } from '../../apis/competition';
-import { patchNotification } from '../../apis/notification';
+import { deleteNotification, patchNotification } from '../../apis/notification';
 import HeaderComponents from '../../components/HeaderComponents';
 import { COLORS } from '../../constants/colors';
 import { FONT_SIZES, FONTS } from '../../constants/font';
@@ -73,6 +72,20 @@ const Notification = ({ navigation }) => {
     switch (notification.type) {
       case 'competition_invite':
         const competitionDetail = await fetchCompetitionDetail(notification.relation_table_id);
+        if (competitionDetail.error) {
+          showToast(
+            '찾으시는 경쟁방이 없어요 🥹',
+            'error',
+            undefined,
+            undefined,
+            undefined,
+            '알림 데이터를 삭제할게요.',
+          );
+          await deleteNotification(notification.id);
+          setNotificationList(notificationList.filter((element) => element.id !== notification.id));
+          return;
+        }
+
         if (competitionDetail.data.info.max_members === 2) {
           navigation.navigate('CompetitionRoom1VS1', {
             competitionId: notification.relation_table_id,

--- a/src/store/notification/index.js
+++ b/src/store/notification/index.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand';
+
+export const useNotificationStore = create((set) => ({
+  notificationList: [],
+  setNotificationList: (notificationList) => {
+    set({ notificationList });
+  },
+}));

--- a/src/store/toastMessage/toastMessage.js
+++ b/src/store/toastMessage/toastMessage.js
@@ -39,7 +39,7 @@ export const useToastMessageStore = create((set) => ({
    * showToast('오류가 발생했습니다.', 'error', 2000, 'bottom', 100);
    */
 
-  showToast: (message, type = 'default', duration = 2000, position = 'top', offSetValue) => {
+  showToast: (message, type = 'default', duration = 2000, position = 'top', offSetValue, subMessage) => {
     let toastConfig = {
       type: type, // 'success', 'error'
       text1: message, // 메인 텍스트
@@ -51,6 +51,10 @@ export const useToastMessageStore = create((set) => ({
       toastConfig.topOffset = offSetValue || getTopOffset();
     } else {
       toastConfig.bottomOffset = offSetValue || getBottomOffset();
+    }
+
+    if (subMessage) {
+      toastConfig.text2 = subMessage;
     }
 
     Toast.show(toastConfig);


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #305

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
- 알림 데이터를 전역상태화 하여 홈 화면에서 불러와 저장하도록 변경했습니다.
- 읽지 않은 알림이 있을 경우 홈 화면 헤더의 아이콘이 변경되도록 했습니다.
- 경쟁방 초대 알림을 눌러 경쟁방 페이지로 이동할 때 경쟁방이 존재하지 않는다면 알림 데이터를 삭제하도록 했습니다.

## ⌛ 소요 시간
