### PR TITLE
Issue 314 경쟁방 페이지 UI 개선

### DIFF
--- a/src/components/CompetitionRoomHeader.jsx
+++ b/src/components/CompetitionRoomHeader.jsx
@@ -65,7 +65,7 @@ const CompetitionRoomHeader = ({ data, progress, onDelete }) => {
               case 'BEFORE':
                 return `🗓️ 시작 D-${startDate.diff(dayjs(), 'days')}`;
               case 'IN_PROGRESS':
-                return `🔥 종료 D-${endDate.diff(dayjs(), 'days')}`;
+                return `🔥 종료 D-${endDate.diff(dayjs(), 'days') > 0 ? endDate.diff(dayjs(), 'days') : 'day'}`;
               case 'AFTER':
                 return '🎉 종료';
             }

--- a/src/components/CompetitionRoomHeader.jsx
+++ b/src/components/CompetitionRoomHeader.jsx
@@ -12,7 +12,7 @@ import { RADIUS } from '../constants/radius';
 import { SPACING } from '../constants/space';
 import CustomTag from './CustomTag';
 
-const CompetitionRoomHeader = ({ data, onDelete }) => {
+const CompetitionRoomHeader = ({ data, progress, onDelete }) => {
   const navigation = useNavigation();
   const startDate = dayjs(data.date.start_date);
   const endDate = dayjs(data.date.end_date);
@@ -59,7 +59,18 @@ const CompetitionRoomHeader = ({ data, onDelete }) => {
       </View>
       <View style={styles.periodWrapper}>
         <Text style={styles.periodText}>{`${startDate.format('YY.MM.DD')}~${endDate.format('YY.MM.DD')}`}</Text>
-        <Text style={styles.periodText}>{`🔥 D-${endDate.diff(dayjs(), 'days')}`}</Text>
+        <Text style={styles.periodText}>
+          {(() => {
+            switch (progress) {
+              case 'BEFORE':
+                return `🗓️ 시작 D-${startDate.diff(dayjs(), 'days')}`;
+              case 'IN_PROGRESS':
+                return `🔥 종료 D-${endDate.diff(dayjs(), 'days')}`;
+              case 'AFTER':
+                return '🎉 종료';
+            }
+          })()}
+        </Text>
       </View>
 
       <Modal transparent visible={showDropdown} onRequestClose={() => setShowDropdown(false)}>

--- a/src/components/MemberProfileItem.jsx
+++ b/src/components/MemberProfileItem.jsx
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 14,
     borderBottomWidth: 1,
-    borderBottomColor: '#303030',
+    borderBottomColor: COLORS.darkBorder,
   },
   profileWrapper: {
     flexDirection: 'row',

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -16,6 +16,8 @@ export const COLORS = {
   lightPurple: '#8B8BFF',
   lightGreen: '#4BD995',
 
+  darkBorder: '#303030',
+
   placeholder: '#888888',
 
   // Background colors

--- a/src/pages/competition/CompetitionRecordDetail.jsx
+++ b/src/pages/competition/CompetitionRecordDetail.jsx
@@ -1,0 +1,83 @@
+import dayjs from 'dayjs';
+import React from 'react';
+import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+
+import HeaderComponents from '../../components/HeaderComponents';
+import { COLORS } from '../../constants/colors';
+import { FONT_SIZES, FONTS } from '../../constants/font';
+
+const CompetitionRecordDetail = ({ navigation, route }) => {
+  const { score_detail } = route.params;
+
+  const renderDiary = ({ item, index }) => {
+    return (
+      <View style={styles.diaryWrapper}>
+        <Text style={styles.diaryTitleText}>
+          {dayjs(item.created_at).format('YYYY년 MM월 DD일')} {item.title}
+        </Text>
+        {item.record.map((e, i) => (
+          <View style={styles.recordWrapper} key={`${index}|${e.set}`}>
+            <Text style={styles.recordText}>{e.set}</Text>
+            <Text style={styles.recordText}>{`${e.weight}kg × ${e.reps}회`}</Text>
+          </View>
+        ))}
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.pageContainer}>
+      <HeaderComponents icon="none" title={score_detail.name} />
+      <FlatList
+        style={{ paddingHorizontal: 20 }}
+        data={score_detail.diary}
+        keyExtractor={(item, index) => `${index}|${item.created_at}`}
+        renderItem={renderDiary}
+        ListFooterComponent={<Text style={styles.scoreText}>점수: {score_detail.score}</Text>}
+        ListEmptyComponent={<Text style={styles.scoreText}>아직 기록이 없어요..</Text>}
+        showsVerticalScrollIndicator={false}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default CompetitionRecordDetail;
+
+const styles = StyleSheet.create({
+  pageContainer: {
+    flex: 1,
+    backgroundColor: COLORS.darkBackground,
+  },
+  titleText: {
+    fontSize: FONT_SIZES.lg,
+    fontFamily: FONTS.PRETENDARD[700],
+    color: COLORS.white,
+  },
+  scoreText: {
+    fontSize: FONT_SIZES.sm,
+    fontFamily: FONTS.PRETENDARD[600],
+    color: COLORS.white,
+    paddingTop: 10,
+  },
+  diaryWrapper: {
+    paddingVertical: 20,
+    gap: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.darkBorder,
+  },
+  diaryTitleText: {
+    fontSize: FONT_SIZES.md,
+    fontFamily: FONTS.PRETENDARD[500],
+    color: COLORS.white,
+    paddingBottom: 4,
+  },
+  recordWrapper: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  recordText: {
+    fontSize: FONT_SIZES.sm,
+    fontFamily: FONTS.PRETENDARD[500],
+    color: COLORS.white,
+  },
+});

--- a/src/pages/competition/CompetitionRecordDetail.jsx
+++ b/src/pages/competition/CompetitionRecordDetail.jsx
@@ -34,7 +34,7 @@ const CompetitionRecordDetail = ({ navigation, route }) => {
         keyExtractor={(item, index) => `${index}|${item.created_at}`}
         renderItem={renderDiary}
         ListFooterComponent={<Text style={styles.scoreText}>점수: {score_detail.score}</Text>}
-        ListEmptyComponent={<Text style={styles.scoreText}>아직 기록이 없어요..</Text>}
+        ListEmptyComponent={<Text style={styles.emptyText}>아직 기록이 없어요..</Text>}
         showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
@@ -58,6 +58,12 @@ const styles = StyleSheet.create({
     fontFamily: FONTS.PRETENDARD[600],
     color: COLORS.white,
     paddingTop: 10,
+  },
+  emptyText: {
+    fontSize: FONT_SIZES.md,
+    fontFamily: FONTS.PRETENDARD[500],
+    color: COLORS.white,
+    paddingTop: 20,
   },
   diaryWrapper: {
     paddingVertical: 20,

--- a/src/pages/competition/CompetitionRoom1VS1.jsx
+++ b/src/pages/competition/CompetitionRoom1VS1.jsx
@@ -260,7 +260,7 @@ const CompetitionRoom1VS1 = ({ navigation }) => {
         return loadingStates.recordDetail ? (
           <SkeletonLoader type="myScore" />
         ) : (
-          <MyScore data={competitionRecordDetail} />
+          <MyScore data={competitionRecordDetail} navigation={navigation} />
         );
       case 'invite':
         return <Invite competitionId={competitionId} friends={myFriends} jumpTo={jumpTo} />;
@@ -272,7 +272,7 @@ const CompetitionRoom1VS1 = ({ navigation }) => {
       {loadingStates.details ? (
         <SkeletonLoader type="header" />
       ) : (
-        competitionData && <CompetitionRoomHeader data={competitionData} onDelete={handleDelete} />
+        competitionData && <CompetitionRoomHeader data={competitionData} progress={progress} onDelete={handleDelete} />
       )}
       <TabView
         renderTabBar={(props) => (

--- a/src/pages/competition/CompetitionRoomRanking.jsx
+++ b/src/pages/competition/CompetitionRoomRanking.jsx
@@ -252,7 +252,7 @@ const CompetitionRoomRanking = ({ navigation }) => {
         return loadingStates.recordDetail ? (
           <SkeletonLoader type="myScore" />
         ) : (
-          <MyScore data={competitionRecordDetail} />
+          <MyScore data={competitionRecordDetail} navigation={navigation} />
         );
       case 'invite':
         return <Invite competitionId={competitionId} friends={myFriends} jumpTo={jumpTo} />;
@@ -264,7 +264,7 @@ const CompetitionRoomRanking = ({ navigation }) => {
       {loadingStates.details ? (
         <SkeletonLoader type="header" />
       ) : (
-        competitionData && <CompetitionRoomHeader data={competitionData} onDelete={handleDelete} />
+        competitionData && <CompetitionRoomHeader data={competitionData} progress={progress} onDelete={handleDelete} />
       )}
       <TabView
         renderTabBar={(props) => (

--- a/src/pages/competition/rankingPageTabs/MyScore.jsx
+++ b/src/pages/competition/rankingPageTabs/MyScore.jsx
@@ -5,14 +5,18 @@ import { COLORS } from '../../../constants/colors';
 import { FONT_SIZES, FONTS } from '../../../constants/font';
 import { LAYOUT_PADDING, SPACING } from '../../../constants/space';
 
-const MyScore = ({ data }) => {
+const MyScore = ({ data, navigation }) => {
   const renderScoreItem = ({ item, index }) => {
     return (
-      <TouchableOpacity style={styles.scoreItemWrapper} activeOpacity={0.6}>
+      <TouchableOpacity
+        style={styles.scoreItemWrapper}
+        activeOpacity={0.6}
+        onPress={() => navigation.navigate('CompetitionRecordDetail', { score_detail: item })}
+      >
         <Text style={styles.exerciseNameText}>{item.name}</Text>
         <View style={{ gap: 4 }}>
           {item.diary[item.diary.length - 1]?.record.map((e, i) => (
-            <View style={styles.recordWrapper}>
+            <View style={styles.recordWrapper} key={`${index}|${e.set}`}>
               <Text style={styles.recordText}>{e.set}</Text>
               <Text style={styles.recordText}>{`${e.weight}kg × ${e.reps}회`}</Text>
             </View>
@@ -42,7 +46,7 @@ const MyScore = ({ data }) => {
           )
         }
         ListFooterComponent={<View style={{ height: 30 }} />}
-        ListEmptyComponent={<Text style={styles.emptyText}>아직 참가하지 않아 내 점수가 없어요..</Text>}
+        ListEmptyComponent={<Text style={styles.emptyText}>아직 내 점수가 없어요..</Text>}
         showsVerticalScrollIndicator={false}
       />
     </View>

--- a/src/pages/competition/rankingPageTabs/RankList.jsx
+++ b/src/pages/competition/rankingPageTabs/RankList.jsx
@@ -169,7 +169,7 @@ const RankList = ({ data, competitionData, progress, onJoin, onLeave }) => {
   };
 
   const renderRankItem = ({ item, index }) => {
-    if (progress === 'IN_PROGRESS') {
+    if (['IN_PROGRESS', 'AFTER'].includes(progress)) {
       return (
         <TouchableOpacity
           style={[
@@ -203,7 +203,7 @@ const RankList = ({ data, competitionData, progress, onJoin, onLeave }) => {
           )}
         </TouchableOpacity>
       );
-    } else if (progress === 'BEFORE') {
+    } else {
       return (
         <View
           style={[

--- a/src/pages/notification/Notification.jsx
+++ b/src/pages/notification/Notification.jsx
@@ -205,7 +205,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: SPACING.sm,
     borderBottomWidth: 1,
-    borderBottomColor: '#303030',
+    borderBottomColor: COLORS.darkBorder,
   },
   notificationWrapper: {
     flexDirection: 'row',

--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ import { setupFirebaseMessaging } from '../firebaseConfig';
 import BottomTab from './components/BottomTab';
 import Competition from './pages/competition/Competition';
 import CompetitionCreation from './pages/competition/CompetitionCreation/CompetitionCreation';
+import CompetitionRecordDetail from './pages/competition/CompetitionRecordDetail';
 import CompetitionRoom1VS1 from './pages/competition/CompetitionRoom1VS1';
 import CompetitionRoomRanking from './pages/competition/CompetitionRoomRanking';
 import SearchCompetition from './pages/competition/SearchCompetition';
@@ -132,6 +133,7 @@ const Router = () => {
       <Stack.Screen name="CompetitionCreation" component={CompetitionCreation} />
       <Stack.Screen name="CompetitionRoom1VS1" component={CompetitionRoom1VS1} />
       <Stack.Screen name="CompetitionRoomRanking" component={CompetitionRoomRanking} />
+      <Stack.Screen name="CompetitionRecordDetail" component={CompetitionRecordDetail} />
       <Stack.Screen name="FriendSearch" component={FriendSearch} />
       <Stack.Screen name="Test" component={Test} />
     </Stack.Navigator>


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #314

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
- 랭킹전 경쟁방 페이지에서 경쟁이 끝난 후 랭킹 리스트가 나타나지 않는 오류를 수정했습니다.
- 경쟁방 헤더의 D-day 텍스트를 진행 상황에 따라 다르게 나타나도록 수정했습니다.
- 경쟁 종목별 세부 기록 페이지를 개발했습니다.
  - 경쟁방 페이지 내 점수 탭에서 각 종목 카드를 클릭하면 세부 기록 페이지로 이동됩니다.
  - 내 점수 탭에서는 가장 최근 일지 데이터만 나타나는 반면, 세부 기록 페이지에서는 모든 일지 데이터가 나타납니다.

## ⌛ 소요 시간
