### PR TITLE
Issue 316 종료된 경쟁방 필터링

### DIFF
--- a/src/components/SkeletonLoader.jsx
+++ b/src/components/SkeletonLoader.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 
-import { COLORS } from '../../../constants/colors';
-import { RADIUS } from '../../../constants/radius';
-import { SPACING } from '../../../constants/space';
+import { COLORS } from '../constants/colors';
+import { RADIUS } from '../constants/radius';
+import { SPACING } from '../constants/space';
 
 const SkeletonLoader = ({ type }) => {
   const fadeAnim = useRef(new Animated.Value(0.3)).current;
@@ -74,6 +74,26 @@ const SkeletonLoader = ({ type }) => {
     </View>
   );
 
+  const renderCompetitionItem = () => (
+    <View style={styles.competitionContainer}>
+      <View style={{ gap: SPACING.xs }}>
+        <View style={styles.titleContainer}>
+          <AnimatedBlock style={{ width: 150, height: 24 }} />
+          <AnimatedBlock style={{ width: 30, height: 24 }} />
+        </View>
+        <View style={{ flexDirection: 'row', gap: SPACING.xxs }}>
+          <AnimatedBlock style={{ width: 60, height: 24 }} />
+          <AnimatedBlock style={{ width: 60, height: 24 }} />
+          <AnimatedBlock style={{ width: 60, height: 24 }} />
+        </View>
+        <AnimatedBlock style={{ width: 120, height: 20 }} />
+      </View>
+      <View style={styles.competitionMemberContainer}>
+        <AnimatedBlock style={{ width: 40, height: 24 }} />
+      </View>
+    </View>
+  );
+
   switch (type) {
     case 'header':
       return renderHeader();
@@ -81,6 +101,8 @@ const SkeletonLoader = ({ type }) => {
       return renderRankList();
     case 'myScore':
       return renderMyScore();
+    case 'competitionItem':
+      return renderCompetitionItem();
     default:
       return null;
   }
@@ -140,6 +162,24 @@ const styles = StyleSheet.create({
   },
   scoreItem: {
     marginBottom: 16,
+  },
+  competitionContainer: {
+    backgroundColor: COLORS.darkGrey,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+    borderRadius: RADIUS.large,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: SPACING.xs,
+  },
+  competitionMemberContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.xs,
   },
 });
 

--- a/src/pages/competition/Competition.jsx
+++ b/src/pages/competition/Competition.jsx
@@ -10,9 +10,11 @@ import { FONT_SIZES, FONTS, HEADER_FONT_SIZES } from '../../constants/font';
 import { RADIUS } from '../../constants/radius';
 import { LAYOUT_PADDING, SPACING } from '../../constants/space';
 import useUserStore from '../../store/sign/login';
+import { getCompetitionProgress } from '../../utils/competition';
 
 const Competition = ({ navigation }) => {
   const [myCompetitions, setMyCompetitions] = useState([]);
+  const [activeCompetitions, setActiveCompetitions] = useState([]);
   const nickname = useUserStore((state) => state.nickname);
   const isFocused = useIsFocused();
 
@@ -21,6 +23,9 @@ const Competition = ({ navigation }) => {
       try {
         const result = await getMyCompetition();
         setMyCompetitions(result.data);
+
+        const active = result.data.filter((data) => getCompetitionProgress(data) !== 'AFTER');
+        setActiveCompetitions(active);
       } catch (error) {
         Alert.alert('내 경쟁방 목록을 불러오는데 실패했습니다', error.message);
       }
@@ -97,12 +102,12 @@ const Competition = ({ navigation }) => {
       <View style={{ ...LAYOUT_PADDING }}>
         <FlatList
           ListHeaderComponent={ListHeader}
-          data={myCompetitions}
+          data={activeCompetitions}
           renderItem={renderCompetitions}
           keyExtractor={(item) => item.id}
           showsVerticalScrollIndicator={false}
           contentContainerStyle={{ gap: SPACING.md }}
-          ListFooterComponent={myCompetitions.length > 0 ? ListFooter : null}
+          ListFooterComponent={activeCompetitions.length > 0 ? ListFooter : null}
           ListEmptyComponent={ListEmpty}
         />
       </View>

--- a/src/pages/competition/CompetitionRoom1VS1.jsx
+++ b/src/pages/competition/CompetitionRoom1VS1.jsx
@@ -14,6 +14,7 @@ import { getCompetitionRecord } from '../../apis/competition';
 import { getMyFriendsNotParticipant } from '../../apis/friend';
 import CompetitionRoomHeader from '../../components/CompetitionRoomHeader';
 import CustomAlert from '../../components/CustomAlert';
+import SkeletonLoader from '../../components/SkeletonLoader';
 import { COLORS } from '../../constants/colors';
 import { FONT_SIZES, FONTS } from '../../constants/font';
 import { useToastMessageStore } from '../../store/toastMessage/toastMessage';
@@ -21,7 +22,6 @@ import { getCompetitionProgress } from '../../utils/competition';
 import Invite from './rankingPageTabs/Invite';
 import MyScore from './rankingPageTabs/MyScore';
 import Score1VS1 from './rankingPageTabs/Score1VS1';
-import SkeletonLoader from './rankingPageTabs/SkeletonLoader';
 
 /* eslint-disable */
 

--- a/src/pages/competition/CompetitionRoomRanking.jsx
+++ b/src/pages/competition/CompetitionRoomRanking.jsx
@@ -14,6 +14,7 @@ import {
 import { getMyFriendsNotParticipant } from '../../apis/friend';
 import CompetitionRoomHeader from '../../components/CompetitionRoomHeader';
 import CustomAlert from '../../components/CustomAlert';
+import SkeletonLoader from '../../components/SkeletonLoader';
 import { COLORS } from '../../constants/colors';
 import { FONT_SIZES, FONTS } from '../../constants/font';
 import { useToastMessageStore } from '../../store/toastMessage/toastMessage';
@@ -21,7 +22,6 @@ import { getCompetitionProgress } from '../../utils/competition';
 import Invite from './rankingPageTabs/Invite';
 import MyScore from './rankingPageTabs/MyScore';
 import RankList from './rankingPageTabs/RankList';
-import SkeletonLoader from './rankingPageTabs/SkeletonLoader';
 
 /* eslint-disable */
 

--- a/src/pages/competition/SearchCompetition.jsx
+++ b/src/pages/competition/SearchCompetition.jsx
@@ -10,6 +10,7 @@ import CustomButton from '../../components/CustomButton';
 import CustomTag from '../../components/CustomTag';
 import DropdownModal from '../../components/DropdownModal';
 import HeaderComponents from '../../components/HeaderComponents';
+import SkeletonLoader from '../../components/SkeletonLoader';
 import { COLORS } from '../../constants/colors';
 import { FONT_SIZES, FONTS } from '../../constants/font';
 import { RADIUS } from '../../constants/radius';
@@ -69,15 +70,19 @@ const SearchCompetition = ({ navigation }) => {
   const [sortBy, setSortBy] = useState('');
   const [selectedTag, setSelectedTag] = useState('');
   const isFocused = useIsFocused();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchCompetitions = async () => {
+      setIsLoading(true);
       try {
         const result = await getAllCompetitions();
         const activeCompetitions = result.data.filter((data) => getCompetitionProgress(data) !== 'AFTER');
         setCompetitions(activeCompetitions);
       } catch (error) {
         Alert.alert('전체 경쟁방 목록을 불러오는데 실패했습니다', error.message);
+      } finally {
+        setIsLoading(false);
       }
     };
 
@@ -171,6 +176,31 @@ const SearchCompetition = ({ navigation }) => {
     [navigation],
   );
 
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <FlatList
+          data={[1]}
+          renderItem={() => <SkeletonLoader type="competitionItem" />}
+          keyExtractor={(item, index) => index.toString()}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ gap: SPACING.md, paddingBottom: 90 }}
+        />
+      );
+    }
+
+    return (
+      <FlatList
+        data={sortedCompetitions}
+        renderItem={renderCompetitions}
+        keyExtractor={(item) => item.id}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ gap: SPACING.md, paddingBottom: 90 }}
+        ListEmptyComponent={ListEmpty}
+      />
+    );
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <HeaderComponents title="경쟁 찾기" />
@@ -198,14 +228,7 @@ const SearchCompetition = ({ navigation }) => {
           />
         </View>
         {/* 경쟁 목록 */}
-        <FlatList
-          data={sortedCompetitions}
-          renderItem={renderCompetitions}
-          keyExtractor={(item) => item.id}
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ gap: SPACING.md, paddingBottom: 90 }}
-          ListEmptyComponent={ListEmpty}
-        />
+        {renderContent()}
       </View>
     </SafeAreaView>
   );

--- a/src/pages/competition/SearchCompetition.jsx
+++ b/src/pages/competition/SearchCompetition.jsx
@@ -14,6 +14,7 @@ import { COLORS } from '../../constants/colors';
 import { FONT_SIZES, FONTS } from '../../constants/font';
 import { RADIUS } from '../../constants/radius';
 import { LAYOUT_PADDING, SPACING } from '../../constants/space';
+import { getCompetitionProgress } from '../../utils/competition';
 import { formDate } from '../../utils/date';
 
 // 경쟁방 아이템 컴포넌트
@@ -73,7 +74,8 @@ const SearchCompetition = ({ navigation }) => {
     const fetchCompetitions = async () => {
       try {
         const result = await getAllCompetitions();
-        setCompetitions(result.data);
+        const activeCompetitions = result.data.filter((data) => getCompetitionProgress(data) !== 'AFTER');
+        setCompetitions(activeCompetitions);
       } catch (error) {
         Alert.alert('전체 경쟁방 목록을 불러오는데 실패했습니다', error.message);
       }

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -17,6 +17,7 @@ import { useCompetitionStore } from '../../store/competition';
 import { useNotificationStore } from '../../store/notification';
 import useUserStore from '../../store/sign/login';
 import { useToastMessageStore } from '../../store/toastMessage/toastMessage';
+import { getCompetitionProgress } from '../../utils/competition';
 
 const defaultProfile = require('../../assets/images/default-profile.png');
 const dummyDates = [
@@ -42,22 +43,30 @@ const Home = ({ navigation }) => {
       if (competitions && competitions.length > 0) {
         const now = new Date(); //현재 날짜
 
-        const closestCompetition = competitions.reduce((closest, current) => {
-          const currentEndDate = new Date(current.end_date);
-          const closestEndDate = new Date(closest.end_date);
+        const activeCompetitions = competitions.filter((data) => getCompetitionProgress(data) !== 'AFTER');
 
-          // 오늘과 종료날짜의 차
-          const currentDifference = Math.abs(currentEndDate - now);
-          const closestDifference = Math.abs(closestEndDate - now);
+        if (activeCompetitions.length > 0) {
+          const closestCompetition = competitions.reduce((closest, current) => {
+            const currentEndDate = new Date(current.end_date);
+            const closestEndDate = new Date(closest.end_date);
 
-          // current의 종료 날짜가 더 가까우면 current return
-          return currentDifference < closestDifference ? current : closest;
-        }, competitions[0]);
+            // 오늘과 종료날짜의 차
+            const currentDifference = Math.abs(currentEndDate - now);
+            const closestDifference = Math.abs(closestEndDate - now);
 
-        setCompetition(closestCompetition);
-        setCompetitionList(competition);
+            // current의 종료 날짜가 더 가까우면 current return
+            return currentDifference < closestDifference ? current : closest;
+          }, activeCompetitions[0]);
+
+          setCompetition(closestCompetition);
+          setCompetitionList(activeCompetitions);
+        } else {
+          setCompetition(null);
+          setCompetitionList([]);
+        }
       } else {
         setCompetition(null);
+        setCompetitionList([]);
       }
     } catch (error) {
       showToast(`Error fetching competitions: ${error.message}`, 'error', 2000, 'top');


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #316

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->

-  종료된 경쟁방은 안보이도록 필터링
    - 창현님이 만들어주신 경쟁방 진행 상태 utils 사용했습니다!
    - 홈화면, 내 경쟁방, 전체 경쟁방에 적용
- 전체 경쟁방 조회시 처음에 잠깐 경쟁방 없을때 나타나는 ListEmpty 컴포넌트가 보이는 문제 → skeleton ui 적용
<img width="300" alt="스크린샷 2024-10-01 오후 2 58 57" src="https://github.com/user-attachments/assets/32a7fd3f-5bfd-4db9-adde-449eb4933942">


## ⌛ 소요 시간
