### PR TITLE
Issue 340 apple 로그인 클라이언트 개발

### DIFF
--- a/ios/Ddait.xcodeproj/project.pbxproj
+++ b/ios/Ddait.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		4659F9CD90F90E12FA392284 /* Pods-Ddait-DdaitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Ddait-DdaitTests.debug.xcconfig"; path = "Target Support Files/Pods-Ddait-DdaitTests/Pods-Ddait-DdaitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7A45DF145EBD4EAF9B4A4B66 /* Pretendard-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Light.ttf"; path = "../src/assets/fonts/Pretendard-Light.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Ddait/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		906A97DC2CC6835F002B3239 /* DdaitDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = DdaitDebug.entitlements; path = Ddait/DdaitDebug.entitlements; sourceTree = "<group>"; };
 		AB61AD19EC504652861D62E1 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Medium.ttf"; path = "../src/assets/fonts/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
 		B636BD93441F4CDE96BA63DE /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Pretendard-Bold.ttf"; path = "../src/assets/fonts/Pretendard-Bold.ttf"; sourceTree = "<group>"; };
 		C15EE5F67AF1F43376C846AE /* Pods-Ddait-DdaitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Ddait-DdaitTests.release.xcconfig"; path = "Target Support Files/Pods-Ddait-DdaitTests/Pods-Ddait-DdaitTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -139,6 +140,7 @@
 		13B07FAE1A68108700A75B9A /* Ddait */ = {
 			isa = PBXGroup;
 			children = (
+				906A97DC2CC6835F002B3239 /* DdaitDebug.entitlements */,
 				1406B87D2C7720710093ACAB /* Fonts */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
@@ -550,6 +552,7 @@
 			baseConfigurationReference = 4659F9CD90F90E12FA392284 /* Pods-Ddait-DdaitTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -577,6 +580,7 @@
 			baseConfigurationReference = C15EE5F67AF1F43376C846AE /* Pods-Ddait-DdaitTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = DdaitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
@@ -602,7 +606,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Ddait/DdaitDebug.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Ddait/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -630,6 +636,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Ddait/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -732,10 +739,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -818,10 +822,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/Ddait/DdaitDebug.entitlements
+++ b/ios/Ddait/DdaitDebug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/src/apis/socialLogin/index.js
+++ b/src/apis/socialLogin/index.js
@@ -13,16 +13,10 @@ export const getUserlevel = async (social_email) => {
     return error;
   }
 };
-export const postAppleLogin = async (identityToken, user, email, fullName) => {
+export const postAppleLogin = async (object) => {
   try {
-    const response = await API.post('/social/login/apple', {
-      identityToken,
-      user,
-      email,
-      fullName,
-    });
-
-    return response;
+    const response = await API.post('/social/login/apple', object);
+    return response.data;
   } catch (error) {
     {
       console.error('apple 로그인시 에러가 발생했습니다.:', error.message);

--- a/src/pages/competition/CompetitionCreation/SetRoomDetail.jsx
+++ b/src/pages/competition/CompetitionCreation/SetRoomDetail.jsx
@@ -13,6 +13,7 @@ import { useToastMessageStore } from '../../../store/toastMessage/toastMessage';
 const { width } = Dimensions.get('window');
 
 import DatePickerBottomSheet from '../../../components/BottomSheet/DatePickerBottomSheet';
+
 const maxMembersOptions = [2, 5, 10, 20];
 
 const SetRoomDetail = () => {


### PR DESCRIPTION
## ✨ PR 세부 내용

- 클라이언트에서@invertase/react-native-apple-authentication 라이브러리를 사용해서 apple로그인
- 애플로그인 서버는 identityToken, nounce값을 클라이언트에 제공
- 클라이언트는 identityToken, nounce값을 서버에 전송
- 서버는 애플 로그인한 유저가 슈퍼베이스를 사용할수있도록 검증하는 로직처리